### PR TITLE
test: use nuttx_deinit to free all resources.

### DIFF
--- a/test/ui.c
+++ b/test/ui.c
@@ -19,16 +19,16 @@
 
 #include "../brightness.h"
 
-static void slider_event_cb(lv_event_t* e);
-static lv_obj_t* slider_label;
+static void slider_event_cb(lv_event_t *e);
+static lv_obj_t *slider_label;
 
 /**
  * A default slider with a label displaying the current value
  */
 
-static void slider_event_cb(lv_event_t* e)
+static void slider_event_cb(lv_event_t *e)
 {
-    lv_obj_t* slider = lv_event_get_target(e);
+    lv_obj_t *slider = lv_event_get_target(e);
     char buf[8];
     lv_snprintf(buf, sizeof(buf), "%d%%", (int)lv_slider_get_value(slider));
     lv_label_set_text(slider_label, buf);
@@ -37,36 +37,37 @@ static void slider_event_cb(lv_event_t* e)
     brightness_set_target(NULL, lv_slider_get_value(slider) * 255 / 100, 1000);
 }
 
-static void switch_event_handler(lv_event_t* e)
+static void switch_event_handler(lv_event_t *e)
 {
     lv_event_code_t code = lv_event_get_code(e);
-    lv_obj_t* obj = lv_event_get_target(e);
+    lv_obj_t *obj = lv_event_get_target(e);
     if (code == LV_EVENT_VALUE_CHANGED) {
         LV_UNUSED(obj);
         bool on = lv_obj_has_state(obj, LV_STATE_CHECKED);
         LV_LOG_USER("State: %s\n", on ? "On" : "Off");
-        brightness_set_mode(NULL, on ? BRIGHTNESS_MODE_AUTO : BRIGHTNESS_MODE_MANUAL);
+        brightness_set_mode(NULL,
+                            on ? BRIGHTNESS_MODE_AUTO : BRIGHTNESS_MODE_MANUAL);
     }
 }
 
-static void button_event_handler(lv_event_t* e)
+static void button_event_handler(lv_event_t *e)
 {
-    bool* run = lv_event_get_user_data(e);
+    bool *run = lv_event_get_user_data(e);
     *run = false;
     fprintf(stderr, "Exit brightness test UI now.\n");
 }
 
-static void ui_brightness(bool* run)
+static void ui_brightness(bool *run)
 {
-    lv_obj_t* root = lv_obj_create(lv_screen_active());
+    lv_obj_t *root = lv_obj_create(lv_screen_active());
     lv_obj_set_size(root, LV_PCT(80), LV_PCT(80));
     lv_obj_center(root);
     lv_obj_set_flex_flow(root, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(root, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-        LV_FLEX_ALIGN_CENTER);
+                          LV_FLEX_ALIGN_CENTER);
 
     /*Create a slider in the center of the display*/
-    lv_obj_t* slider = lv_slider_create(root);
+    lv_obj_t *slider = lv_slider_create(root);
     lv_obj_set_width(slider, LV_PCT(80));
     lv_obj_center(slider);
     lv_obj_add_event_cb(slider, slider_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
@@ -78,24 +79,24 @@ static void ui_brightness(bool* run)
 
     lv_obj_align_to(slider_label, slider, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
 
-    lv_obj_t* cont = lv_obj_create(root);
+    lv_obj_t *cont = lv_obj_create(root);
     lv_obj_set_size(cont, LV_PCT(100), LV_SIZE_CONTENT);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-        LV_FLEX_ALIGN_CENTER);
+                          LV_FLEX_ALIGN_CENTER);
 
-    lv_obj_t* hint = lv_label_create(cont);
+    lv_obj_t *hint = lv_label_create(cont);
     lv_label_set_text(hint, "AutoBrightness");
-    lv_obj_t* sw = lv_switch_create(cont);
+    lv_obj_t *sw = lv_switch_create(cont);
     lv_obj_add_event_cb(sw, switch_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
 
-    lv_obj_t* btn = lv_button_create(root);
-    lv_obj_t* label = lv_label_create(btn);
+    lv_obj_t *btn = lv_button_create(root);
+    lv_obj_t *label = lv_label_create(btn);
     lv_label_set_text(label, "EXIT");
     lv_obj_add_event_cb(btn, button_event_handler, LV_EVENT_CLICKED, run);
 }
 
-int brightness_test_ui(int argc, FAR char* argv[])
+int brightness_test_ui(int argc, FAR char *argv[])
 {
     lv_nuttx_dsc_t info;
     lv_nuttx_result_t result;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

